### PR TITLE
Update webinar dates across multiple components to reflect the new sc…

### DIFF
--- a/app/api/webhook/webinar/route.ts
+++ b/app/api/webhook/webinar/route.ts
@@ -193,7 +193,7 @@ async function sendConfirmationEmail(emailData: { email: string; amount: number;
               <div style="border: 1px solid #dee2e6; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);">
                 <div style="padding: 16px 20px; border-bottom: 1px solid #e9ecef; background: linear-gradient(90deg, #f8f9fa 0%, #ffffff 100%);">
                   <div style="color: #6c757d; font-size: 12px; font-weight: 600; margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px;">Dates</div>
-                  <div style="color: #212529; font-size: 15px; font-weight: 600;">22nd August - 4th September, 2025</div>
+                  <div style="color: #212529; font-size: 15px; font-weight: 600;">27th August - 9th September, 2025</div>
                 </div>
                 <div style="padding: 16px 20px; border-bottom: 1px solid #e9ecef; background-color: #ffffff;">
                   <div style="color: #6c757d; font-size: 12px; font-weight: 600; margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px;">Time</div>

--- a/app/webinars/[id]/page.tsx
+++ b/app/webinars/[id]/page.tsx
@@ -83,7 +83,7 @@ export default function WebinarDetailsPage() {
     "docker-kubernetes-bootcamp": {
       title: "Docker & Kubernetes Mastery – 2-Week Live Bootcamp",
       isLive: true,
-      date: "22nd August - 4th September, 2025",
+      date: "27th August - 9th September, 2025",
       time: "10:00 AM - 11:00 AM IST (Mon-Fri)",
       duration: "2 weeks, 1 hour each day (weekdays only)",
       fee: "₹2,999",

--- a/components/HeroSection/HeroSection.tsx
+++ b/components/HeroSection/HeroSection.tsx
@@ -371,7 +371,7 @@ export function HeroSectionOne() {
               <div className="flex-1 flex flex-col gap-2">
                 <div className="flex items-center gap-3 mb-2">
                   <span className="inline-block bg-blue-600 text-white rounded-lg px-2 py-1 font-bold text-lg">Live</span>
-                  <span className="text-blue-700 font-semibold text-lg">22nd August - 4th September, 2025</span>
+                  <span className="text-blue-700 font-semibold text-lg">27th August - 9th September, 2025</span>
                 </div>
                 <div className="text-lg font-semibold text-blue-900 mb-1">Docker & Kubernetes Mastery – 2-Week Live Bootcamp</div>
                 <div className="text-gray-700 mb-2 text-base max-w-xl">

--- a/components/Webinars/Webinars.tsx
+++ b/components/Webinars/Webinars.tsx
@@ -63,7 +63,7 @@ const webinars: WebinarCard[] = [
 ✅ Hands-on Labs & Real Projects
 ✅ Industry Expert Sessions
 ✅ Certificate of Completion`,
-    date: "22nd August - 4th September, 2025",
+    date: "27th August - 9th September, 2025",
     time: "10:00 AM - 11:00 AM IST (Mon-Fri)",
     duration: "2 weeks, 1 hour each day (weekdays only)",
     fee: "₹2,999",


### PR DESCRIPTION
…hedule for the Docker & Kubernetes Mastery bootcamp, changing the dates from "22nd August - 4th September, 2025" to "27th August - 9th September, 2025" in the WebinarDetailsPage, HeroSection, and Webinars components for consistency.